### PR TITLE
gradio_4_43_0_version_upgrade

### DIFF
--- a/demo_app/requirements.txt
+++ b/demo_app/requirements.txt
@@ -1,4 +1,4 @@
-gradio==4.41.0
+gradio==4.43.0
 python-dotenv==1.0.1
 pillow==10.3.0
 PyMuPDF==1.24.4


### PR DESCRIPTION
gradio version 4.41.0 was resulting in 500s on certain deployments/clients. Upgrading to 4.43.0 [resolves this](https://github.com/fastapi/fastapi/issues/12133#issuecomment-2333698258).