### PR TITLE
Storage account: allowSharedKeyAccess=true

### DIFF
--- a/infra/main.bicep
+++ b/infra/main.bicep
@@ -127,6 +127,7 @@ resource blobStorageAccount 'Microsoft.Storage/storageAccounts@2023-01-01' = {
   properties: {
     supportsHttpsTrafficOnly: true
     defaultToOAuthAuthentication: true
+    allowSharedKeyAccess: true
     allowBlobPublicAccess: false
   }
 }


### PR DESCRIPTION
Allow key-based auth for Azure Storage by default