### PR TITLE
Optional resource deployment

### DIFF
--- a/azure.yaml
+++ b/azure.yaml
@@ -6,17 +6,28 @@ metadata:
 hooks:
   postprovision: 
     # Create all content understanding analyzers defined in the content_understanding_schemas.json file
+    # This hook will only run if the Content Understanding resource is deployed and the endpoint URL is 
+    # available in the "CONTENT_UNDERSTANDING_ENDPOINT" Bicep output (which is automatically set as
+    # an env var when running this hook).
     posix:
       shell: sh
-      # Use azd env get-values to access the Bicep output and (re)create the content understanding analyzers
-      run: export CONTENT_UNDERSTANDING_ENDPOINT=$(azd env get-values | grep CONTENT_UNDERSTANDING_ENDPOINT | cut -d'=' -f2 | tr -d '"') && python ./function_app/create_content_understanding_analyzers.py
+      run: |
+        if [ -n "$CONTENT_UNDERSTANDING_ENDPOINT" ] && [ "$CONTENT_UNDERSTANDING_ENDPOINT" != "null" ]; then
+          python ./function_app/create_content_understanding_analyzers.py
+        else
+          echo "Skipping Content Understanding analyzer creation - the resource has not been deployed and/or no endpoint URL is available in the Bicep outputs"
+        fi
       interactive: false
       continueOnError: false
       
     windows:
       shell: pwsh
-      # Use azd env get-values to access the Bicep output and (re)create the content understanding analyzers
-      run: Set-Item env:CONTENT_UNDERSTANDING_ENDPOINT ((azd env get-values | Select-String "CONTENT_UNDERSTANDING_ENDPOINT" | ForEach-Object {$_.ToString().Split('=')[1].Trim('"')})); python ./function_app/create_content_understanding_analyzers.py
+      run: |
+        if ($env:CONTENT_UNDERSTANDING_ENDPOINT) {
+          python ./function_app/create_content_understanding_analyzers.py
+        } else {
+          Write-Host "Skipping Content Understanding analyzer creation - the resource has not been deployed and/or no endpoint URL is available in the Bicep outputs"
+        }
       interactive: false
       continueOnError: false
 services:

--- a/azure.yaml
+++ b/azure.yaml
@@ -41,27 +41,28 @@ services:
     host: appservice
     hooks:
       prepackage: 
-        # Copy the content_understanding_schemas.json file to the demo_app directory to give it knowledge of the deployed content understanding schemas
+        # Copy the content_understanding_schemas.json file to the demo_app directory to give it knowledge of the deployed content understanding schemas,
+        # and move the .env file since .webappignore (https://learn.microsoft.com/en-us/azure/developer/azure-developer-cli/service-packaging-ignore-files) does not seem to work.
         posix:
           shell: sh
-          run: cp ../function_app/config/content_understanding_schemas.json ./
+          run: cp ../function_app/config/content_understanding_schemas.json ./ && mv ./.env ../.demo_app.env.bak
           interactive: false
           continueOnError: false
         windows:
           shell: pwsh
-          run: copy ../function_app/config/content_understanding_schemas.json ./
+          run: copy ../function_app/config/content_understanding_schemas.json ./ && mv ./.env ../.demo_app.env.bak
           interactive: false
           continueOnError: false
       postpackage: 
-        # Remove the content_understanding_schemas.json file from the demo_app directory
+        # Remove the content_understanding_schemas.json file from the demo_app directory and restore the .env file
         posix:
           shell: sh
-          run: rm ./content_understanding_schemas.json
+          run: rm ./content_understanding_schemas.json && mv ../.demo_app.env.bak ./.env
           interactive: false
           continueOnError: false
         windows:
           shell: pwsh
-          run: del ./content_understanding_schemas.json
+          run: del ./content_understanding_schemas.json && mv ../.demo_app.env.bak ./.env
           interactive: false
           continueOnError: false
       postdeploy:

--- a/demo_app/.webappignore
+++ b/demo_app/.webappignore
@@ -1,0 +1,4 @@
+.env
+__pycache__/*
+.venv/*
+*.pyc

--- a/function_app/.funcignore
+++ b/function_app/.funcignore
@@ -1,5 +1,7 @@
 .venv
-tests
+__pycache__/*
+tests/*
 sample_local.settings.json
+local.settings.json
 send_req_summarize_text.sh
 setup_env.sh

--- a/function_app/function_app.py
+++ b/function_app/function_app.py
@@ -2,22 +2,15 @@ import logging
 import os
 
 import azure.functions as func
-from bp_call_center_audio_analysis import bp_call_center_audio_analysis
-from bp_content_understanding_audio import bp_content_understanding_audio
-from bp_content_understanding_document import bp_content_understanding_document
-from bp_content_understanding_image import bp_content_understanding_image
-from bp_content_understanding_video import bp_content_understanding_video
-from bp_doc_intel_extract_city_names import bp_doc_intel_extract_city_names
-from bp_form_extraction_with_confidence import bp_form_extraction_with_confidence
-from bp_multimodal_doc_intel_processing import bp_multimodal_doc_intel_processing
-from bp_pii_redaction import bp_pii_redaction
-from bp_summarize_text import bp_summarize_text
 from dotenv import load_dotenv
-from extract_blob_field_info_to_cosmosdb import get_structured_extraction_func_outputs
 
 load_dotenv()
 
-COSMOSDB_DATABASE_NAME = os.getenv("COSMOSDB_DATABASE_NAME")
+logging.basicConfig(
+    level=logging.INFO,
+    format="%(asctime)s:%(levelname)s:%(message)s",
+    datefmt="%Y-%m-%d %H:%M:%S",
+)
 
 # Reduce Azure SDK logging level
 _logger = logging.getLogger("azure")
@@ -25,44 +18,88 @@ _logger.setLevel(logging.WARNING)
 
 app = func.FunctionApp(http_auth_level=func.AuthLevel.FUNCTION)
 
+### Read environment variables to determine which backend resources/services are deployed
+IS_CONTENT_UNDERSTANDING_DEPLOYED = (
+    os.getenv("CONTENT_UNDERSTANDING_ENDPOINT") is not None
+)
+IS_AOAI_DEPLOYED = os.getenv("AOAI_ENDPOINT") is not None
+IS_DOC_INTEL_DEPLOYED = os.getenv("DOC_INTEL_ENDPOINT") is not None
+IS_SPEECH_DEPLOYED = os.getenv("SPEECH_ENDPOINT") is not None
+IS_LANGUAGE_DEPLOYED = os.getenv("LANGUAGE_ENDPOINT") is not None
+IS_COSMOSDB_AVAILABLE = os.getenv("COSMOSDB_DATABASE_NAME") and os.getenv(
+    "CosmosDbConnectionSetting__accountEndpoint"
+)
 
-### Register blueprints for HTTP functions
-app.register_blueprint(bp_form_extraction_with_confidence)
-app.register_blueprint(bp_call_center_audio_analysis)
-app.register_blueprint(bp_summarize_text)
-app.register_blueprint(bp_doc_intel_extract_city_names)
-app.register_blueprint(bp_multimodal_doc_intel_processing)
-app.register_blueprint(bp_content_understanding_document)
-app.register_blueprint(bp_content_understanding_video)
-app.register_blueprint(bp_content_understanding_audio)
-app.register_blueprint(bp_content_understanding_image)
-app.register_blueprint(bp_pii_redaction)
+### Register blueprints for HTTP functions, provided the relevant backend AI services are deployed
+### and the relevant environment variables are set
+if IS_AOAI_DEPLOYED:
+    from bp_summarize_text import bp_summarize_text
+
+    app.register_blueprint(bp_summarize_text)
+if IS_DOC_INTEL_DEPLOYED and IS_AOAI_DEPLOYED:
+    from bp_form_extraction_with_confidence import bp_form_extraction_with_confidence
+
+    app.register_blueprint(bp_form_extraction_with_confidence)
+if IS_SPEECH_DEPLOYED and IS_AOAI_DEPLOYED:
+    from bp_call_center_audio_analysis import bp_call_center_audio_analysis
+
+    app.register_blueprint(bp_call_center_audio_analysis)
+if IS_DOC_INTEL_DEPLOYED:
+    from bp_doc_intel_extract_city_names import bp_doc_intel_extract_city_names
+    from bp_multimodal_doc_intel_processing import bp_multimodal_doc_intel_processing
+
+    app.register_blueprint(bp_doc_intel_extract_city_names)
+    app.register_blueprint(bp_multimodal_doc_intel_processing)
+if IS_CONTENT_UNDERSTANDING_DEPLOYED:
+    from bp_content_understanding_audio import bp_content_understanding_audio
+    from bp_content_understanding_document import bp_content_understanding_document
+    from bp_content_understanding_image import bp_content_understanding_image
+    from bp_content_understanding_video import bp_content_understanding_video
+
+    app.register_blueprint(bp_content_understanding_document)
+    app.register_blueprint(bp_content_understanding_video)
+    app.register_blueprint(bp_content_understanding_audio)
+    app.register_blueprint(bp_content_understanding_image)
+if IS_LANGUAGE_DEPLOYED:
+    from bp_pii_redaction import bp_pii_redaction
+
+    app.register_blueprint(bp_pii_redaction)
 
 
 ### Define functions with input/output binding decorators (these do not work when defined in blueprint files).
-@app.function_name("blob_form_extraction_to_cosmosdb")
-@app.blob_trigger(
-    arg_name="inputblob",
-    path="blob-form-to-cosmosdb-blobs/{name}",  # Triggered by any blobs created in this container
-    connection="AzureWebJobsStorage",
-)
-@app.cosmos_db_output(
-    arg_name="outputdocument",
-    connection="CosmosDbConnectionSetting",
-    database_name=COSMOSDB_DATABASE_NAME,
-    container_name="blob-form-to-cosmosdb-container",
-)
-def extract_blob_pdf_fields_to_cosmosdb(
-    inputblob: func.InputStream, outputdocument: func.Out[func.Document]
-):
-    """
-    Extracts field information from a PDF and writes the extracted information
-    to CosmosDB.
 
-    :param inputblob: The input blob to process.
-    :type inputblob: func.InputStream
-    :param outputdocument: The output document to write to CosmosDB.
-    :type outputdocument: func.Out[func.Document]
-    """
-    output_result = get_structured_extraction_func_outputs(inputblob)
-    outputdocument.set(func.Document.from_dict(output_result))
+## Blob storage -> CosmosDB Document Processing Pipeline
+# Only register the function if CosmosDB information is available
+if IS_COSMOSDB_AVAILABLE and IS_AOAI_DEPLOYED and IS_DOC_INTEL_DEPLOYED:
+    from extract_blob_field_info_to_cosmosdb import (
+        get_structured_extraction_func_outputs,
+    )
+
+    COSMOSDB_DATABASE_NAME = os.getenv("COSMOSDB_DATABASE_NAME")
+
+    @app.function_name("blob_form_extraction_to_cosmosdb")
+    @app.blob_trigger(
+        arg_name="inputblob",
+        path="blob-form-to-cosmosdb-blobs/{name}",  # Triggered by any blobs created in this container
+        connection="AzureWebJobsStorage",
+    )
+    @app.cosmos_db_output(
+        arg_name="outputdocument",
+        connection="CosmosDbConnectionSetting",
+        database_name=COSMOSDB_DATABASE_NAME,
+        container_name="blob-form-to-cosmosdb-container",
+    )
+    def extract_blob_pdf_fields_to_cosmosdb(
+        inputblob: func.InputStream, outputdocument: func.Out[func.Document]
+    ):
+        """
+        Extracts field information from a PDF and writes the extracted information
+        to CosmosDB.
+
+        :param inputblob: The input blob to process.
+        :type inputblob: func.InputStream
+        :param outputdocument: The output document to write to CosmosDB.
+        :type outputdocument: func.Out[func.Document]
+        """
+        output_result = get_structured_extraction_func_outputs(inputblob)
+        outputdocument.set(func.Document.from_dict(output_result))

--- a/infra/main.bicepparam
+++ b/infra/main.bicepparam
@@ -1,12 +1,15 @@
 using 'main.bicep'
 
-// Function & web apps
+//// Function & web apps
 param appendUniqueUrlSuffix = true
 
+// Function app
 param functionAppName = 'ai-llm-processing-func'
 param functionAppUsePremiumSku = true
 
-param deployWebApp = true // Set to false to skip deployment of the web app
+// Web app
+// If web app deployment is not required, set deployWebApp to false and remove the webapp service deployment from the azure.yaml file
+param deployWebApp = true
 param webAppName = 'ai-llm-processing-demo'
 param webAppUsePasswordAuth = true
 param webAppUsername = 'admin'
@@ -25,7 +28,8 @@ param additionalRoleAssignmentIdentityIds = []
 // Storage service options
 param storageAccountName = 'llmprocstorage'
 
-// Cognitive services
+//// Cognitive services
+
 // Ensure your speech service location has model availability for the methods you need - see:
 // 1. https://learn.microsoft.com/en-us/azure/ai-services/speech-service/regions
 // 2. https://learn.microsoft.com/en-us/azure/ai-services/speech-service/fast-transcription-create#prerequisites

--- a/infra/main.bicepparam
+++ b/infra/main.bicepparam
@@ -1,5 +1,7 @@
 using 'main.bicep'
 
+param tags = {}
+
 //// Function & web apps
 param appendUniqueUrlSuffix = true
 
@@ -20,7 +22,8 @@ param resourcePrefix = 'llm-proc'
 
 // Optionally give access to additional identities. This allows you to 
 // run the application locally while connecting to cloud services using 
-// identity-based authentication.
+// identity-based authentication. This is required to create the Content 
+// Understanding analyzers using the postprovision hook.
 // To get your identity ID, run the following command in the Azure CLI:
 // > az ad signed-in-user show --query id -o tsv
 param additionalRoleAssignmentIdentityIds = []
@@ -28,34 +31,41 @@ param additionalRoleAssignmentIdentityIds = []
 // Storage service options
 param storageAccountName = 'llmprocstorage'
 
+// CosmosDB
+param deployCosmosDB = true
+
 //// Cognitive services
 
+// Speech
+param deploySpeechResource = true
 // Ensure your speech service location has model availability for the methods you need - see:
 // 1. https://learn.microsoft.com/en-us/azure/ai-services/speech-service/regions
 // 2. https://learn.microsoft.com/en-us/azure/ai-services/speech-service/fast-transcription-create#prerequisites
-param deploySpeechResource = true
 param speechLocation = 'eastus'
 
+// Document Intelligence
+param deployDocIntelResource = true
 // Doc Intelligence API v4.0 is only supported in some regions. To make use of the custom
 // DocumentIntelligenceProcessor, make sure to select a region where v4.0 is supported. See:
 // 1. https://learn.microsoft.com/en-us/azure/ai-services/document-intelligence/versioning/changelog-release-history
-param deployDocIntelResource = true
 param docIntelLocation = 'eastus'
 
+// Content Understanding
+param deployContentUnderstandingMultiServicesResource = true
 // Ensure your Content Understanding resource is deployed to a supported location - see:
 // 1. https://learn.microsoft.com/en-us/azure/ai-services/content-understanding/language-region-support?tabs=document#region-support
-param deployContentUnderstandingMultiServicesResource = true
 param contentUnderstandingLocation = 'westus'
 
+// Language
+param deployLanguageResource = true
 // Ensure your Language resource is deployed to a region that supports all required features - see:
 // 1. https://learn.microsoft.com/en-us/azure/ai-services/language-service/concepts/regional-support
-param deployLanguageResource = true
 param languageLocation = 'eastus'
 
 // Azure OpenAI options
+param deployOpenAIResource = true
 // Ensure your OpenAI service locations have model availability - see:
 // 1. https://learn.microsoft.com/en-us/azure/ai-services/openai/quotas-limits#regional-quota-limits
-param deployOpenAIResource = true
 param openAILocation = 'eastus2'
 
 param openAILLMDeploymentCapacity = 30 // Set to 0 to skip deployment

--- a/infra/main.bicepparam
+++ b/infra/main.bicepparam
@@ -6,6 +6,7 @@ param appendUniqueUrlSuffix = true
 param functionAppName = 'ai-llm-processing-func'
 param functionAppUsePremiumSku = true
 
+param deployWebApp = true // Set to false to skip deployment of the web app
 param webAppName = 'ai-llm-processing-demo'
 param webAppUsePasswordAuth = true
 param webAppUsername = 'admin'
@@ -28,30 +29,37 @@ param storageAccountName = 'llmprocstorage'
 // Ensure your speech service location has model availability for the methods you need - see:
 // 1. https://learn.microsoft.com/en-us/azure/ai-services/speech-service/regions
 // 2. https://learn.microsoft.com/en-us/azure/ai-services/speech-service/fast-transcription-create#prerequisites
+param deploySpeechResource = true
 param speechLocation = 'eastus'
 
 // Doc Intelligence API v4.0 is only supported in some regions. To make use of the custom
 // DocumentIntelligenceProcessor, make sure to select a region where v4.0 is supported. See:
 // 1. https://learn.microsoft.com/en-us/azure/ai-services/document-intelligence/versioning/changelog-release-history
+param deployDocIntelResource = true
 param docIntelLocation = 'eastus'
 
 // Ensure your Content Understanding resource is deployed to a supported location - see:
 // 1. https://learn.microsoft.com/en-us/azure/ai-services/content-understanding/language-region-support?tabs=document#region-support
+param deployContentUnderstandingMultiServicesResource = true
 param contentUnderstandingLocation = 'westus'
 
 // Ensure your Language resource is deployed to a region that supports all required features - see:
 // 1. https://learn.microsoft.com/en-us/azure/ai-services/language-service/concepts/regional-support
+param deployLanguageResource = true
 param languageLocation = 'eastus'
 
 // Azure OpenAI options
 // Ensure your OpenAI service locations have model availability - see:
 // 1. https://learn.microsoft.com/en-us/azure/ai-services/openai/quotas-limits#regional-quota-limits
+param deployOpenAIResource = true
 param openAILocation = 'eastus2'
-param openAILLMDeploymentCapacity = 30
+
+param openAILLMDeploymentCapacity = 30 // Set to 0 to skip deployment
 param openAILLMModel = 'gpt-4o'
 param openAILLMModelVersion = '2024-05-13'
 param openAILLMDeploymentSku = 'Standard'
-param openAIWhisperDeploymentCapacity = 1
+
+param openAIWhisperDeploymentCapacity = 1 // Set to 0 to skip deployment
 param openAIWhisperModel = 'whisper'
 param openAIWhisperModelVersion = '001'
 param openAIWhisperDeploymentSku = 'Standard'


### PR DESCRIPTION
Adds simple deployment flags for most backend services, making it easy to enable or disable services depending on what is required for the use case. The services that can be easily toggled are:
* The demo web app
* AOAI
* Content Understanding multi-service resource
* Language
* Document Intelligence
* Speech
* CosmosDB

The main function app file also intelligently imports and registers blueprints based on whether the backend services have been deployed and their deployment info are available in the environment variables (avoiding errors in case a resource has not been deployed), and the demo app only creates the CosmosDB -> Storage pipeline tab if the deployment is available.