### PR TITLE
Add Secure Networking options

### DIFF
--- a/azure.yaml
+++ b/azure.yaml
@@ -17,7 +17,7 @@ hooks:
         else
           echo "Skipping Content Understanding analyzer creation - the resource has not been deployed and/or no endpoint URL is available in the Bicep outputs"
         fi
-      interactive: false
+      interactive: true
       continueOnError: false
       
     windows:
@@ -28,7 +28,7 @@ hooks:
         } else {
           Write-Host "Skipping Content Understanding analyzer creation - the resource has not been deployed and/or no endpoint URL is available in the Bicep outputs"
         }
-      interactive: false
+      interactive: true
       continueOnError: false
 services:
   api:
@@ -65,15 +65,15 @@ services:
           run: del ./content_understanding_schemas.json && mv ../.demo_app.env.bak ./.env
           interactive: false
           continueOnError: false
-      postdeploy:
-        # Install the required Python packages
-        windows:
-          shell: pwsh
-          run: python3 -m pip install --upgrade pip; python3 -m pip install -r requirements.txt
-          interactive: false
-          continueOnError: false
-        posix:
-          shell: sh
-          run: python3 -m pip install --upgrade pip && python3 -m pip install -r requirements.txt
-          interactive: false
-          continueOnError: false
+      # postdeploy:
+      #   # Install the required Python packages
+      #   windows:
+      #     shell: pwsh
+      #     run: python3 -m pip install --upgrade pip; python3 -m pip install -r requirements.txt
+      #     interactive: false
+      #     continueOnError: false
+      #   posix:
+      #     shell: sh
+      #     run: python3 -m pip install --upgrade pip && python3 -m pip install -r requirements.txt
+      #     interactive: false
+      #     continueOnError: false

--- a/azure.yaml
+++ b/azure.yaml
@@ -65,15 +65,3 @@ services:
           run: del ./content_understanding_schemas.json && mv ../.demo_app.env.bak ./.env
           interactive: false
           continueOnError: false
-      # postdeploy:
-      #   # Install the required Python packages
-      #   windows:
-      #     shell: pwsh
-      #     run: python3 -m pip install --upgrade pip; python3 -m pip install -r requirements.txt
-      #     interactive: false
-      #     continueOnError: false
-      #   posix:
-      #     shell: sh
-      #     run: python3 -m pip install --upgrade pip && python3 -m pip install -r requirements.txt
-      #     interactive: false
-      #     continueOnError: false

--- a/infra/main.bicep
+++ b/infra/main.bicep
@@ -266,7 +266,8 @@ resource vnet 'Microsoft.Network/virtualNetworks@2023-05-01' = {
         vnetAddressPrefix
       ]
     }
-    subnets: [
+    subnets: concat(
+      [
       {
         name: backendServicesSubnetName
         properties: {
@@ -402,6 +403,9 @@ resource vnet 'Microsoft.Network/virtualNetworks@2023-05-01' = {
           )
         }
       }
+      ],
+      functionAppNetworkingType == 'PrivateEndpoint'
+        ? [
       {
         name: functionAppPrivateEndpointSubnetName
         properties: {
@@ -414,6 +418,8 @@ resource vnet 'Microsoft.Network/virtualNetworks@2023-05-01' = {
         }
       }
     ]
+        : []
+    )
   }
 }
 

--- a/infra/main.bicep
+++ b/infra/main.bicep
@@ -1112,7 +1112,6 @@ resource docIntel 'Microsoft.CognitiveServices/accounts@2024-10-01' = if (deploy
     customSubDomainName: docIntelTokenName
     disableLocalAuth: true
     networkAcls: {
-      bypass: 'None'
       defaultAction: 'Deny'
       virtualNetworkRules: backendServicesNetworkingType == 'ServiceEndpoint'
         ? [
@@ -1203,7 +1202,6 @@ resource speech 'Microsoft.CognitiveServices/accounts@2024-10-01' = if (deploySp
     customSubDomainName: speechTokenName
     disableLocalAuth: true
     networkAcls: {
-      bypass: 'None'
       defaultAction: 'Deny'
       // Only include VNET rules when using service endpoints
       virtualNetworkRules: backendServicesNetworkingType == 'ServiceEndpoint'

--- a/infra/main.bicepparam
+++ b/infra/main.bicepparam
@@ -81,32 +81,31 @@ param openAIWhisperDeploymentSku = 'Standard'
 // Networking configuration
 
 // By default, all of the resources deployed in this accelerator are networked together using either Service Endpoints or Private Endpoints.
-// The configuration options below allow you to select which of these options are used and optionally allow access from public networks.
+// The configuration options below allow you to select which of these options are used and to optionally allow additional access from public networks.
 
-// 1. Private Endpoints - This restricts all traffic to the backend resources to within the VNET and ensures no data traverses the public internet.
-// Note: if `NetworkingType = PrivateEndpoint` is used for any of the resources, all public access is disabled and the `*AllowPublicAccess` & `*ExternalIpsOrIpRanges` parameters will be ignored.
-
-// 2. Service Endpoints - This allows traffic to reach the resources via the public internet, but controls access to the resources using NACLs and IP rules.
+// 1. Private Endpoints - This deploys a private endpoint for the group of resources and ensures all traffic to the resources stays within the VNET (no data traverses the public internet).
+// 2. Service Endpoints - This uses Service Endpoints & NACL/IP rules to control internal VNET traffic, while ensuring the traffic stays within the Azure backbone network.
 // Note: All access rules between the deployed resources are already configured, but you can also allow public network access using the `*AllowPublicAccess` & `*ExternalIpsOrIpRanges` parameters.
-// If deploying the accelerator from a local machine over the public internet, make sure to enable public network access and add your local IP address to the `*ExternalIpsOrIpRanges` parameters.
+
+// Additionally, you can optionally allow public network access to the resources using the `*AllowPublicAccess` & `*AllowedExternalIpsOrIpRanges` parameters.
+// If deploying the accelerator from a local machine over the public internet, make sure to enable public network access and add your local IP address to the `*AllowedExternalIpsOrIpRanges` parameters.
 // * To disable all public network access and restrict it to only those which have a route from within the VNET, set the `*AllowPublicAccess` parameter to false. 
 //    - Note that this will prevent the setup of the Content Understanding schemas and the deployment of the application code unless the deployment is done from within the VNET.
-// * To enable public network access from any IP address on the internet, set the `*AllowPublicAccess` parameter to true and leave the `*ExternalIpsOrIpRanges` parameter empty
-// * To enable public network access but restrict it to only selected IP addresses, set the '*AllowPublicAccess' to true and set the '*ExternalIpsOrIpRanges' parameter to an array of allowed IP addresses or CIDR blocks
-//    - Values can be either a specific IP address or a CIDR block of IP address ranges (CIDR blocks must be less /30 or less)
-//    - e.g. '123.45.67.0/24' allows an IP address range, and '123.45.67.89' allows a specific IP address
+// * To enable public network access from any IP address on the internet, set the `*AllowPublicAccess` parameter to true and leave the `*AllowedExternalIpsOrIpRanges` parameter empty
+// * To enable public network access but restrict it to only selected IP addresses, set the '*AllowPublicAccess' to true and included the allowed IP address in the the '*AllowedExternalIpsOrIpRanges' parameters
 
+param webAppUsePrivateEndpoint = false
 param webAppAllowPublicAccess = true
-param webAppExternalIpsOrIpRanges = []
+param webAppAllowedExternalIpRanges = [] // Use CIDR blocks for all entries
 
 param functionAppNetworkingType = 'ServiceEndpoint'
 param functionAppAllowPublicAccess = true
-param functionAppExternalIpsOrIpRanges = []
+param functionAppAllowedExternalIpRanges = [] // Use CIDR blocks for all entries
 
 param backendServicesNetworkingType = 'ServiceEndpoint'
 param backendServicesAllowPublicAccess = true
-param backendServicesExternalIpsOrIpRanges = []
+param backendServicesAllowedExternalIpsOrIpRanges = [] // Use CIDR blocks for IP ranges (up to /30), otherwise use specific IP addresses.
 
 param storageServicesAndKVNetworkingType = 'ServiceEndpoint'
 param storageServicesAndKVAllowPublicAccess = true
-param storageServicesAndKVExternalIpsOrIpRanges = []
+param storageServicesAndKVAllowedExternalIpsOrIpRanges = [] // Use CIDR blocks for IP ranges (up to /30), otherwise use specific IP addresses.

--- a/infra/main.bicepparam
+++ b/infra/main.bicepparam
@@ -77,3 +77,36 @@ param openAIWhisperDeploymentCapacity = 1 // Set to 0 to skip deployment
 param openAIWhisperModel = 'whisper'
 param openAIWhisperModelVersion = '001'
 param openAIWhisperDeploymentSku = 'Standard'
+
+// Networking configuration
+
+// By default, all of the resources deployed in this accelerator are networked together using either Service Endpoints or Private Endpoints.
+// The configuration options below allow you to select which of these options are used and optionally allow access from public networks.
+
+// 1. Private Endpoints - This restricts all traffic to the backend resources to within the VNET and ensures no data traverses the public internet.
+// Note: if `NetworkingType = PrivateEndpoint` is used for any of the resources, all public access is disabled and the `*AllowPublicAccess` & `*ExternalIpsOrIpRanges` parameters will be ignored.
+
+// 2. Service Endpoints - This allows traffic to reach the resources via the public internet, but controls access to the resources using NACLs and IP rules.
+// Note: All access rules between the deployed resources are already configured, but you can also allow public network access using the `*AllowPublicAccess` & `*ExternalIpsOrIpRanges` parameters.
+// If deploying the accelerator from a local machine over the public internet, make sure to enable public network access and add your local IP address to the `*ExternalIpsOrIpRanges` parameters.
+// * To disable all public network access and restrict it to only those which have a route from within the VNET, set the `*AllowPublicAccess` parameter to false. 
+//    - Note that this will prevent the setup of the Content Understanding schemas and the deployment of the application code unless the deployment is done from within the VNET.
+// * To enable public network access from any IP address on the internet, set the `*AllowPublicAccess` parameter to true and leave the `*ExternalIpsOrIpRanges` parameter empty
+// * To enable public network access but restrict it to only selected IP addresses, set the '*AllowPublicAccess' to true and set the '*ExternalIpsOrIpRanges' parameter to an array of allowed IP addresses or CIDR blocks
+//    - Values can be either a specific IP address or a CIDR block of IP address ranges (CIDR blocks must be less /30 or less)
+//    - e.g. '123.45.67.0/24' allows an IP address range, and '123.45.67.89' allows a specific IP address
+
+param webAppAllowPublicAccess = true
+param webAppExternalIpsOrIpRanges = []
+
+param functionAppNetworkingType = 'ServiceEndpoint'
+param functionAppAllowPublicAccess = true
+param functionAppExternalIpsOrIpRanges = []
+
+param backendServicesNetworkingType = 'ServiceEndpoint'
+param backendServicesAllowPublicAccess = true
+param backendServicesExternalIpsOrIpRanges = []
+
+param storageServicesAndKVNetworkingType = 'ServiceEndpoint'
+param storageServicesAndKVAllowPublicAccess = true
+param storageServicesAndKVExternalIpsOrIpRanges = []


### PR DESCRIPTION
This branch adds more secure networking options and allows for access rule configuration.

* Defines the VNET & subnet configuration for different layers of the application
* Sets subnet-based rules for internal communication. These rules govern the inter-app communication (e.g. web app to function app & storage accounts, or function app to backend services).
* Gives the user the option to use Service Endpoints or Private endpoints for transport between all front-end/backend/storage/AI resources.
* Allows independent control of public network access to the application and the ability to restrict that access to specific IP addresses or CIDR blocks.
* Updates the README and bicep.params file with more info on how to configure these options